### PR TITLE
fix: always parse bucket `Contents` as an array

### DIFF
--- a/routes/metrics.js
+++ b/routes/metrics.js
@@ -52,7 +52,9 @@ module.exports = async function (fastify, opts) {
       const response = await undici.request(url, {
         dispatcher: agent
       })
-      const parser = new XMLParser()
+      const parser = new XMLParser({
+        isArray: (tagName) => tagName === "Contents",
+      })
       const obj = parser.parse(await response.body.text())
 
       for (const key of obj.ListBucketResult.Contents) {


### PR DESCRIPTION
The site doesn't work today, the `/metrics` endpoint returns a 500 error:

![image](https://github.com/user-attachments/assets/6c9bb0d4-6e73-45ec-9080-7da56b5ec301)

After some investigation, I found that today at [storage.googleapis.com/access-logs-summaries-nodejs/?max-keys=100&marker=nodejs.org-access.log.20241130.json](https://storage.googleapis.com/access-logs-summaries-nodejs/?max-keys=100&marker=nodejs.org-access.log.20241130.json), there is only one `<Contents>` element in the xml:

```xml
<ListBucketResult xmlns="http://doc.s3.amazonaws.com/2006-03-01">
<Name>access-logs-summaries-nodejs</Name>
<Prefix/>
<Marker>nodejs.org-access.log.20241130.json</Marker>
<MaxKeys>100</MaxKeys>
<IsTruncated>false</IsTruncated>
	<Contents>
		<Key>nodejs.org-access.log.20241201.json</Key>
		<Generation>1733140874831363</Generation>
		<MetaGeneration>1</MetaGeneration>
		<LastModified>2024-12-02T12:01:14.875Z</LastModified>
		<ETag>"d432afec7966666bf9705010a72b8813"</ETag>
		<Size>12659</Size>
	</Contents>
</ListBucketResult>
```

Because of this, [fast-xml-parser](https://github.com/NaturalIntelligence/fast-xml-parser/) parses the `<Contents>` as an object, instead of an array. We can use  the [isArray](https://github.com/NaturalIntelligence/fast-xml-parser/blob/408290231ed0aeb38cdfc55f9866dda1669c123c/docs/v5/3.Options.md#parser-configuration) option to force the parser to treat this element as an array always.