### PR TITLE
Move computation to backend /chart-data route

### DIFF
--- a/public/count.js
+++ b/public/count.js
@@ -9,76 +9,6 @@ function getTextColor () {
   return getComputedStyle(document.body).getPropertyValue('--color-text')
 }
 
-function computeDataSet (labels, versions, includeAll = true) {
-  const all = labels.map((label) => 0)
-
-  const datasets = Object.keys(versions).map((version) => {
-    const downloadsCounts = {}
-
-    for (const { date, downloads } of versions[version]) {
-      const month = date.substring(0, 7) // Extract YYYY-MM from YYYY-MM-DD
-      downloadsCounts[month] = (downloadsCounts[month] || 0) + downloads
-    }
-
-    const data = labels.map((label) => downloadsCounts[label] || 0)
-
-    for (let i = 0; i < data.length; i++) {
-      all[i] += data[i]
-    }
-
-    return {
-      label: version,
-      data,
-      fill: true,
-      showLine: true
-    }
-  })
-
-  if (includeAll) {
-    datasets.push({
-      label: 'All',
-      data: all,
-      fill: false,
-      showLine: true
-    })
-  }
-
-  return datasets
-}
-
-function generateCSV(json) {
-  const csv = []
-  csv.push('Month,Version,Operating System,Downloads')
-  
-  // Aggregate version data by month
-  Object.keys(json.versions).forEach(version => {
-    const monthlyData = {}
-    json.versions[version].forEach(({ date, downloads }) => {
-      const month = date.substring(0, 7) // Extract YYYY-MM
-      monthlyData[month] = (monthlyData[month] || 0) + downloads
-    })
-    
-    Object.keys(monthlyData).forEach(month => {
-      csv.push(`${month},${version},,${monthlyData[month]}`)
-    })
-  })
-  
-  // Aggregate operating system data by month
-  Object.keys(json.operatingSystems).forEach(os => {
-    const monthlyData = {}
-    json.operatingSystems[os].forEach(({ date, downloads }) => {
-      const month = date.substring(0, 7) // Extract YYYY-MM
-      monthlyData[month] = (monthlyData[month] || 0) + downloads
-    })
-    
-    Object.keys(monthlyData).forEach(month => {
-      csv.push(`${month},,${os},${monthlyData[month]}`)
-    })
-  })
-  
-  return csv.join('\n')
-}
-
 function downloadCSV(csv) {
   const blob = new Blob([csv], { type: 'text/csv' })
   const url = window.URL.createObjectURL(blob)
@@ -90,7 +20,7 @@ function downloadCSV(csv) {
 }
 
 async function updateChart () {
-  const response = await fetch('/metrics')
+  const response = await fetch('/chart-data')
 
   const json = await response.json()
 
@@ -101,55 +31,20 @@ async function updateChart () {
   }
 
   if (json.error) {
-    console.error('Error fetching metrics:', json.error)
-    return;
-  } else {
-    document.querySelectorAll('.skeleton').forEach((el) => el.classList.add('hidden'))
+    console.error('Error fetching chart data:', json.error)
+    return
   }
 
-  const versions = json.versions
+  // Hide skeleton loading elements
+  document.querySelectorAll('.skeleton').forEach((el) => el.classList.add('hidden'))
 
-  // Get all unique months from both versions and operating systems
-  const allMonths = new Set()
-  
-  // Add months from version data
-  for (const versionData of Object.values(versions)) {
-    for (const { date } of versionData) {
-      allMonths.add(date.substring(0, 7)) // Extract YYYY-MM
-    }
-  }
-  
-  // Add months from OS data
-  if (json.operatingSystems) {
-    for (const osData of Object.values(json.operatingSystems)) {
-      for (const { date } of osData) {
-        allMonths.add(date.substring(0, 7)) // Extract YYYY-MM
-      }
-    }
-  }
-  
-  const labels = [...allMonths].sort()
+  const { labels, versionChart, osChart, csv } = json
 
-  // Your chart data
-  var data = {
-    labels,
-    datasets: computeDataSet(labels, versions)
-  };
-
-  // Your chart data
-  var data2 = {
-    labels,
-    datasets: computeDataSet(labels, json.operatingSystems, false)
-  };
-
-  var ctx = document.getElementById('downloadsChart').getContext('2d');
-  var ctx2 = document.getElementById('byOperatingSystem').getContext('2d');
-
-  var borderColor = getBorderColor();
-  var textColor = getTextColor();
+  const borderColor = getBorderColor()
+  const textColor = getTextColor()
 
   // Configuration options
-  var options = {
+  const options = {
     responsive: true,
     aspectRatio: 1.5,
     maintainAspectRatio: true,
@@ -173,20 +68,27 @@ async function updateChart () {
         },
       },
     },
-  };
+  }
 
-
-  // Create the line chart
+  // Create the version chart
+  const ctx = document.getElementById('downloadsChart').getContext('2d')
   downloadsChart = new Chart(ctx, {
     type: 'line',
-    data: data,
+    data: {
+      labels,
+      datasets: versionChart.datasets
+    },
     options: options
-  });
+  })
 
-  // Create the line chart
+  // Create the OS chart (stacked)
+  const ctx2 = document.getElementById('byOperatingSystem').getContext('2d')
   byOperatingSystems = new Chart(ctx2, {
     type: 'line',
-    data: data2,
+    data: {
+      labels,
+      datasets: osChart.datasets
+    },
     options: {
       ...options,
       scales: {
@@ -197,27 +99,28 @@ async function updateChart () {
         }
       }
     }
-  });
-  
+  })
+
   // Setup CSV download
   document.getElementById('csvDownload').addEventListener('click', (e) => {
     e.preventDefault()
-    const csv = generateCSV(json)
     downloadCSV(csv)
   })
 }
 
 window.matchMedia('(prefers-color-scheme: dark)')
   .addEventListener('change', event => {
-    var borderColor = getBorderColor();
-    var textColor = getTextColor();
+    const borderColor = getBorderColor()
+    const textColor = getTextColor()
 
     for (const chart of [downloadsChart, byOperatingSystems]) {
-      chart.options.color = textColor
-      chart.options.scales.x.grid.color = borderColor
-      chart.options.scales.y.grid.color = borderColor
-      chart.options.scales.x.ticks.color = textColor
-      chart.options.scales.y.ticks.color = textColor
-      chart.update()
+      if (chart) {
+        chart.options.color = textColor
+        chart.options.scales.x.grid.color = borderColor
+        chart.options.scales.y.grid.color = borderColor
+        chart.options.scales.x.ticks.color = textColor
+        chart.options.scales.y.ticks.color = textColor
+        chart.update()
+      }
     }
   })

--- a/routes/chart-data.js
+++ b/routes/chart-data.js
@@ -1,0 +1,161 @@
+/// <reference path="../global.d.ts" />
+'use strict'
+
+/** @param {import('fastify').FastifyInstance} fastify */
+module.exports = async function (fastify, opts) {
+  const db = fastify.db
+  if (!db) {
+    throw new Error('Database not initialized - ensure database plugin is registered before chart-data routes')
+  }
+
+  /**
+   * Compute chart data from monthly aggregated database data
+   * Returns pre-computed data ready for Chart.js
+   */
+  function computeChartData () {
+    // Get monthly aggregated data from database
+    const monthlyVersionRows = db.getMonthlyVersionDownloads()
+    const monthlyOsRows = db.getMonthlyOsDownloads()
+
+    // Collect all unique months from both datasets
+    const allMonths = new Set()
+
+    // Add months from version data
+    for (const { month } of monthlyVersionRows) {
+      allMonths.add(month)
+    }
+
+    // Add months from OS data
+    for (const { month } of monthlyOsRows) {
+      allMonths.add(month)
+    }
+
+    // Sort months chronologically
+    const labels = [...allMonths].sort()
+
+    // Build version chart datasets
+    // Group by major version first
+    const versionData = {}
+    for (const { major_version, month, total_downloads } of monthlyVersionRows) {
+      const key = String(major_version)
+      if (!versionData[key]) {
+        versionData[key] = {}
+      }
+      versionData[key][month] = total_downloads
+    }
+
+    // Create datasets array for Chart.js
+    const versionDatasets = []
+    const versionTotals = labels.map(() => 0)
+
+    for (const version of Object.keys(versionData).sort((a, b) => Number(a) - Number(b))) {
+      const data = labels.map((month, index) => {
+        const downloads = versionData[version][month] || 0
+        versionTotals[index] += downloads
+        return downloads
+      })
+
+      versionDatasets.push({
+        label: version,
+        data,
+        fill: true,
+        showLine: true
+      })
+    }
+
+    // Add 'All' dataset (sum of all versions)
+    versionDatasets.push({
+      label: 'All',
+      data: versionTotals,
+      fill: false,
+      showLine: true
+    })
+
+    // Build OS chart datasets (stacked)
+    const osData = {}
+    for (const { os, month, total_downloads } of monthlyOsRows) {
+      if (!osData[os]) {
+        osData[os] = {}
+      }
+      osData[os][month] = total_downloads
+    }
+
+    const osDatasets = []
+    for (const os of Object.keys(osData).sort()) {
+      const data = labels.map((month) => osData[os][month] || 0)
+
+      osDatasets.push({
+        label: os,
+        data,
+        fill: true,
+        showLine: true
+      })
+    }
+
+    // Generate CSV data
+    const csv = generateCSV(labels, versionData, osData)
+
+    return {
+      labels,
+      versionChart: {
+        datasets: versionDatasets
+      },
+      osChart: {
+        datasets: osDatasets
+      },
+      csv
+    }
+  }
+
+  /**
+   * Generate CSV data from aggregated monthly data
+   */
+  function generateCSV (labels, versionData, osData) {
+    const csv = []
+    csv.push('Month,Version,Operating System,Downloads')
+
+    // Add version data rows
+    for (const version of Object.keys(versionData).sort((a, b) => Number(a) - Number(b))) {
+      for (const month of labels) {
+        const downloads = versionData[version][month] || 0
+        if (downloads > 0) {
+          csv.push(`${month},${version},,${downloads}`)
+        }
+      }
+    }
+
+    // Add OS data rows
+    for (const os of Object.keys(osData).sort()) {
+      for (const month of labels) {
+        const downloads = osData[os][month] || 0
+        if (downloads > 0) {
+          csv.push(`${month},,${os},${downloads}`)
+        }
+      }
+    }
+
+    return csv.join('\n')
+  }
+
+  fastify.get('/chart-data', async (request, reply) => {
+    // Check if data is available
+    const versionRows = db.getMonthlyVersionDownloads()
+
+    if (versionRows.length === 0) {
+      reply.code(503)
+      reply.header('Retry-After', '30')
+      return {
+        error: 'Data is still loading',
+        message: 'Initial data load in progress - chart data not available yet'
+      }
+    }
+
+    const chartData = computeChartData()
+
+    // Cache headers - content is stable for 1 hour
+    const oneHour = 60 * 60
+    reply.header('Cache-Control', `max-age=${oneHour}, s-maxage=${oneHour}, stale-while-revalidate=${oneHour}, stale-if-error=${oneHour}`)
+
+    return chartData
+  })
+}

--- a/routes/metrics.js
+++ b/routes/metrics.js
@@ -18,6 +18,9 @@ module.exports = async function (fastify, opts) {
   let isReady = false
   let ingestionProgress = { processed: 0, total: 0, isLoading: true }
 
+  // Expose ingestion status to other routes (e.g., chart-data)
+  fastify.decorate('ingestionProgress', ingestionProgress)
+
   // Start ingestion in background (non-blocking with yields)
   ingester.ingestWithProgress((progress) => {
     ingestionProgress = { ...progress, isLoading: true }

--- a/test/routes/chart-data.test.js
+++ b/test/routes/chart-data.test.js
@@ -1,0 +1,299 @@
+'use strict'
+
+const assert = require('node:assert')
+const test = require('node:test')
+const fastify = require('fastify')
+const path = require('node:path')
+
+// Import the chart-data route
+const chartDataRoute = require('../../routes/chart-data.js')
+
+test('chart-data returns 503 when no data available', async () => {
+  const app = fastify()
+
+  // Mock database with no data
+  const mockDb = {
+    getMonthlyVersionDownloads: () => [],
+    getMonthlyOsDownloads: () => []
+  }
+  app.decorate('db', mockDb)
+
+  await app.register(chartDataRoute, {})
+
+  const response = await app.inject({
+    method: 'GET',
+    url: '/chart-data'
+  })
+
+  assert.strictEqual(response.statusCode, 503)
+  const json = JSON.parse(response.payload)
+  assert.ok(json.error.includes('still loading'))
+
+  await app.close()
+})
+
+test('chart-data returns labels from all months', async () => {
+  const app = fastify()
+
+  const mockDb = {
+    getMonthlyVersionDownloads: () => [
+      { major_version: 18, month: '2024-01', total_downloads: 100 },
+      { major_version: 20, month: '2024-02', total_downloads: 200 }
+    ],
+    getMonthlyOsDownloads: () => [
+      { os: 'linux', month: '2024-03', total_downloads: 300 }
+    ]
+  }
+  app.decorate('db', mockDb)
+
+  await app.register(chartDataRoute, {})
+
+  const response = await app.inject({
+    method: 'GET',
+    url: '/chart-data'
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  const json = JSON.parse(response.payload)
+
+  // Labels should include all unique months from both datasets
+  assert.deepStrictEqual(json.labels, ['2024-01', '2024-02', '2024-03'])
+
+  await app.close()
+})
+
+test('chart-data version chart has datasets for each version plus All', async () => {
+  const app = fastify()
+
+  const mockDb = {
+    getMonthlyVersionDownloads: () => [
+      { major_version: 18, month: '2024-01', total_downloads: 100 },
+      { major_version: 18, month: '2024-02', total_downloads: 150 },
+      { major_version: 20, month: '2024-01', total_downloads: 200 },
+      { major_version: 20, month: '2024-02', total_downloads: 250 }
+    ],
+    getMonthlyOsDownloads: () => []
+  }
+  app.decorate('db', mockDb)
+
+  await app.register(chartDataRoute, {})
+
+  const response = await app.inject({
+    method: 'GET',
+    url: '/chart-data'
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  const json = JSON.parse(response.payload)
+
+  // Should have datasets for version 18, 20, and All
+  assert.strictEqual(json.versionChart.datasets.length, 3)
+
+  const labels = json.versionChart.datasets.map(d => d.label)
+  assert.ok(labels.includes('18'))
+  assert.ok(labels.includes('20'))
+  assert.ok(labels.includes('All'))
+
+  await app.close()
+})
+
+test('chart-data version datasets have correct data points', async () => {
+  const app = fastify()
+
+  const mockDb = {
+    getMonthlyVersionDownloads: () => [
+      { major_version: 18, month: '2024-01', total_downloads: 100 },
+      { major_version: 18, month: '2024-02', total_downloads: 150 },
+      { major_version: 20, month: '2024-01', total_downloads: 200 },
+      { major_version: 20, month: '2024-02', total_downloads: 250 }
+    ],
+    getMonthlyOsDownloads: () => []
+  }
+  app.decorate('db', mockDb)
+
+  await app.register(chartDataRoute, {})
+
+  const response = await app.inject({
+    method: 'GET',
+    url: '/chart-data'
+  })
+
+  const json = JSON.parse(response.payload)
+
+  // Find version 18 dataset
+  const v18 = json.versionChart.datasets.find(d => d.label === '18')
+  // Data should be [100, 150] for Jan, Feb
+  assert.deepStrictEqual(v18.data, [100, 150])
+
+  // Find version 20 dataset
+  const v20 = json.versionChart.datasets.find(d => d.label === '20')
+  // Data should be [200, 250] for Jan, Feb
+  assert.deepStrictEqual(v20.data, [200, 250])
+
+  // Find All dataset
+  const all = json.versionChart.datasets.find(d => d.label === 'All')
+  // Data should be [300, 400] (sum of both versions)
+  assert.deepStrictEqual(all.data, [300, 400])
+
+  await app.close()
+})
+
+test('chart-data All total equals sum of all version datasets', async () => {
+  const app = fastify()
+
+  const mockDb = {
+    getMonthlyVersionDownloads: () => [
+      { major_version: 18, month: '2024-01', total_downloads: 100 },
+      { major_version: 18, month: '2024-02', total_downloads: 200 },
+      { major_version: 18, month: '2024-03', total_downloads: 300 },
+      { major_version: 20, month: '2024-01', total_downloads: 400 },
+      { major_version: 20, month: '2024-02', total_downloads: 500 },
+      { major_version: 20, month: '2024-03', total_downloads: 600 }
+    ],
+    getMonthlyOsDownloads: () => []
+  }
+  app.decorate('db', mockDb)
+
+  await app.register(chartDataRoute, {})
+
+  const response = await app.inject({
+    method: 'GET',
+    url: '/chart-data'
+  })
+
+  const json = JSON.parse(response.payload)
+
+  const v18 = json.versionChart.datasets.find(d => d.label === '18').data
+  const v20 = json.versionChart.datasets.find(d => d.label === '20').data
+  const all = json.versionChart.datasets.find(d => d.label === 'All').data
+
+  // Verify All = v18 + v20 for each month
+  for (let i = 0; i < all.length; i++) {
+    assert.strictEqual(all[i], v18[i] + v20[i], `Month ${i}: All should equal v18 + v20`)
+  }
+
+  await app.close()
+})
+
+test('chart-data os chart has datasets for each os', async () => {
+  const app = fastify()
+
+  const mockDb = {
+    getMonthlyVersionDownloads: () => [
+      { major_version: 18, month: '2024-01', total_downloads: 100 }
+    ],
+    getMonthlyOsDownloads: () => [
+      { os: 'linux', month: '2024-01', total_downloads: 50 },
+      { os: 'win', month: '2024-01', total_downloads: 30 },
+      { os: 'osx', month: '2024-01', total_downloads: 20 }
+    ]
+  }
+  app.decorate('db', mockDb)
+
+  await app.register(chartDataRoute, {})
+
+  const response = await app.inject({
+    method: 'GET',
+    url: '/chart-data'
+  })
+
+  const json = JSON.parse(response.payload)
+
+  // Should have datasets for each OS
+  assert.strictEqual(json.osChart.datasets.length, 3)
+
+  const labels = json.osChart.datasets.map(d => d.label)
+  assert.ok(labels.includes('linux'))
+  assert.ok(labels.includes('win'))
+  assert.ok(labels.includes('osx'))
+
+  await app.close()
+})
+
+test('chart-data datasets have correct Chart.js properties', async () => {
+  const app = fastify()
+
+  const mockDb = {
+    getMonthlyVersionDownloads: () => [
+      { major_version: 18, month: '2024-01', total_downloads: 100 }
+    ],
+    getMonthlyOsDownloads: () => []
+  }
+  app.decorate('db', mockDb)
+
+  await app.register(chartDataRoute, {})
+
+  const response = await app.inject({
+    method: 'GET',
+    url: '/chart-data'
+  })
+
+  const json = JSON.parse(response.payload)
+
+  // Check version datasets
+  for (const dataset of json.versionChart.datasets) {
+    assert.ok(Array.isArray(dataset.data), 'Dataset should have data array')
+    assert.ok(typeof dataset.label === 'string', 'Dataset should have label')
+    assert.strictEqual(dataset.fill, dataset.label === 'All' ? false : true, 'Fill property should be set')
+    assert.strictEqual(dataset.showLine, true, 'showLine should be true')
+  }
+
+  await app.close()
+})
+
+test('chart-data returns CSV data', async () => {
+  const app = fastify()
+
+  const mockDb = {
+    getMonthlyVersionDownloads: () => [
+      { major_version: 18, month: '2024-01', total_downloads: 100 },
+      { major_version: 20, month: '2024-01', total_downloads: 200 }
+    ],
+    getMonthlyOsDownloads: () => [
+      { os: 'linux', month: '2024-01', total_downloads: 300 }
+    ]
+  }
+  app.decorate('db', mockDb)
+
+  await app.register(chartDataRoute, {})
+
+  const response = await app.inject({
+    method: 'GET',
+    url: '/chart-data'
+  })
+
+  const json = JSON.parse(response.payload)
+
+  // Should have CSV string
+  assert.ok(typeof json.csv === 'string', 'CSV should be a string')
+  assert.ok(json.csv.includes('Month,Version,Operating System,Downloads'), 'CSV should have header')
+  assert.ok(json.csv.includes('2024-01,18,,100'), 'CSV should have version data')
+  assert.ok(json.csv.includes('2024-01,,linux,300'), 'CSV should have OS data')
+
+  await app.close()
+})
+
+test('chart-data returns cache headers', async () => {
+  const app = fastify()
+
+  const mockDb = {
+    getMonthlyVersionDownloads: () => [
+      { major_version: 18, month: '2024-01', total_downloads: 100 }
+    ],
+    getMonthlyOsDownloads: () => []
+  }
+  app.decorate('db', mockDb)
+
+  await app.register(chartDataRoute, {})
+
+  const response = await app.inject({
+    method: 'GET',
+    url: '/chart-data'
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  assert.ok(response.headers['cache-control'], 'Should have Cache-Control header')
+  assert.ok(response.headers['cache-control'].includes('max-age=3600'), 'Should cache for 1 hour')
+
+  await app.close()
+})

--- a/test/routes/root.test.js
+++ b/test/routes/root.test.js
@@ -107,10 +107,10 @@ test('count.js has valid JavaScript syntax', async () => {
   }
 })
 
-test('count.js fetches metrics from correct endpoint', async () => {
+test('count.js fetches chart-data from correct endpoint', async () => {
   const countJsPath = path.join(__dirname, '../../public/count.js')
   const content = fs.readFileSync(countJsPath, 'utf-8')
 
-  assert.ok(content.includes("fetch('/metrics')"),
-    'count.js should fetch from /metrics endpoint')
+  assert.ok(content.includes("fetch('/chart-data')"),
+    'count.js should fetch from /chart-data endpoint')
 })


### PR DESCRIPTION
Move all frontend computation to new `/chart-data` backend route

**What changed:**
- **New route:** `/chart-data` returns pre-computed data ready for Chart.js
- **Labels:** All unique months from both version and OS data (chronologically sorted)  
- **Version chart:** Dataset for each major version + 'All' total line
- **OS chart:** Dataset for each operating system (stacked configuration)
- **CSV:** Pre-generated CSV string for download
- **Caching:** 1-hour cache headers for performance

**Frontend simplification:**
```javascript
// Before: Complex computation in count.js
const datasets = computeDataSet(labels, versions)
const all = datasets.pop()

// After: Just fetch and render
const { labels, versionChart, osChart, csv } = await response.json()
new Chart(ctx, { data: versionChart })
```

**Why this matters:**
- Eliminates client-side computation bugs (like the version 4 label issue)
- Single source of truth for aggregation logic
- Faster frontend - just JSON to Chart.js
- Easier to test (backend route has 9 comprehensive tests)

**Tests added:**
- 503 response when no data
- Labels include all months from both datasets
- Version chart has datasets for each version plus All
- All total equals sum of version datasets (regression test)
- OS chart has datasets for each OS
- Chart.js properties correctly set
- CSV data format
- Cache headers present

**Total tests: 26** (all passing)
