### PR TITLE
Add debug logging and admin API for ingestion

### DIFF
--- a/lib/ingest.js
+++ b/lib/ingest.js
@@ -20,6 +20,15 @@ class DataIngester {
     // Allow passing custom agent for testing (e.g., MockAgent)
     this.agent = agent || new undici.Agent({ connections: 10 })
     this.isIngesting = false
+    this.lastError = null
+    this.stats = {
+      totalFiles: 0,
+      processedFiles: 0,
+      versionRecords: 0,
+      osRecords: 0,
+      errors: 0,
+      byVersion: {}
+    }
   }
 
   async ingest () {
@@ -29,6 +38,15 @@ class DataIngester {
     }
 
     this.isIngesting = true
+    this.lastError = null
+    this.stats = {
+      totalFiles: 0,
+      processedFiles: 0,
+      versionRecords: 0,
+      osRecords: 0,
+      errors: 0,
+      byVersion: {}
+    }
     this.logger.info('Starting data ingestion from GCS')
 
     try {
@@ -50,6 +68,8 @@ class DataIngester {
 
       // Fetch available files from GCS (only new data since mostRecentDate)
       const availableData = await this.listAvailableFiles(mostRecentDate)
+      this.stats.totalFiles = availableData.length
+      this.logger.info({ totalFiles: availableData.length }, 'Found files to process')
 
       // Skip current month as it doesn't have all the data yet
       const today = new Date()
@@ -57,16 +77,18 @@ class DataIngester {
 
       // Get dates already in the database to avoid re-ingesting
       const existingDates = new Set(this.db.getExistingDates())
-      this.logger.info({ count: existingDates.size }, 'Found existing dates in database')
+      this.logger.info({ existingDates: existingDates.size }, 'Found existing dates in database')
 
       // Filter out:
       // 1. Dates already in the database (from previous runs/restarts)
       // 2. Current incomplete month
       const toDownload = availableData.filter(({ date }) => {
         if (existingDates.has(date)) {
+          this.logger.debug({ date }, 'Skipping - already in database')
           return false
         }
         if (date.startsWith(currentMonth)) {
+          this.logger.debug({ date, currentMonth }, 'Skipping - current month')
           return false
         }
         return true
@@ -83,68 +105,116 @@ class DataIngester {
 
       for (const { date, url } of toDownload) {
         try {
+          this.logger.debug({ date, url }, 'Fetching daily stats file')
           const response = await undici.request(url, { dispatcher: this.agent })
           const result = await response.body.json()
 
-          // Accumulate version data
+          // Debug: log all version keys found
           const versionKeys = Object.keys(result.version || {})
+          this.logger.debug({ 
+            date, 
+            versionCount: versionKeys.length,
+            sampleVersions: versionKeys.slice(0, 5)
+          }, 'Found versions in file')
+          
+          let versionsInserted = 0
           for (const key of versionKeys) {
+            this.logger.trace({ key, date }, 'Parsing version')
             const version = semver.parse(key)
-            if (!version) continue
-            if (version.major < 4) continue
+            if (!version) {
+              this.logger.warn({ key, date }, 'Failed to parse version - skipping')
+              continue
+            }
+            if (version.major < 4) {
+              this.logger.trace({ key, major: version.major, date }, 'Skipping version < 4')
+              continue
+            }
 
+            this.logger.trace({ date, version: key, major: version.major, downloads: result.version[key] }, 'Adding to version batch')
             versionBatch.push({
               date,
               majorVersion: version.major,
               downloads: result.version[key]
             })
+            versionsInserted++
+            this.stats.versionRecords++
+            
+            // Track by version for debugging
+            if (!this.stats.byVersion[version.major]) {
+              this.stats.byVersion[version.major] = 0
+            }
+            this.stats.byVersion[version.major]++
+
+            // Flush batch when it reaches threshold
+            if (versionBatch.length >= BATCH_SIZE) {
+              this.logger.debug({ batchSize: versionBatch.length }, 'Flushing version batch')
+              this.db.insertVersionDownloadsBatch(versionBatch.splice(0, BATCH_SIZE))
+            }
           }
+          this.logger.debug({ date, versionsInserted }, 'Added versions for date')
 
           // Accumulate OS data
           const osKeys = Object.keys(result.os || {})
+          let osInserted = 0
           for (const os of osKeys) {
+            this.logger.trace({ date, os, downloads: result.os[os] }, 'Adding to OS batch')
             osBatch.push({
               date,
               os,
               downloads: result.os[os]
             })
+            osInserted++
+            this.stats.osRecords++
+
+            // Flush batch when it reaches threshold
+            if (osBatch.length >= BATCH_SIZE) {
+              this.logger.debug({ batchSize: osBatch.length }, 'Flushing OS batch')
+              this.db.insertOsDownloadsBatch(osBatch.splice(0, BATCH_SIZE))
+            }
           }
+          this.logger.debug({ date, osInserted }, 'Added OS records for date')
 
           processed++
-
-          // Flush batches when they reach threshold
-          if (versionBatch.length >= BATCH_SIZE) {
-            this.db.insertVersionDownloadsBatch(versionBatch.splice(0, BATCH_SIZE))
-          }
-          if (osBatch.length >= BATCH_SIZE) {
-            this.db.insertOsDownloadsBatch(osBatch.splice(0, BATCH_SIZE))
-          }
-
-          // Yield every 10 files to prevent event loop blocking on HTTP requests
+          this.stats.processedFiles = processed
           if (processed % 10 === 0) {
-            this.logger.info({ processed, total: toDownload.length, versionQueue: versionBatch.length, osQueue: osBatch.length }, 'Ingestion progress')
+            this.logger.info({ 
+              processed, 
+              total: toDownload.length,
+              versionRecords: this.stats.versionRecords,
+              osRecords: this.stats.osRecords,
+              versionQueue: versionBatch.length,
+              osQueue: osBatch.length,
+              byVersion: this.stats.byVersion
+            }, 'Ingestion progress')
             await new Promise(resolve => setImmediate(resolve))
           } else {
-            this.logger.debug({ date }, 'Processed daily stats')
+            this.logger.debug({ date, versions: versionKeys.length }, 'Processed daily stats')
           }
         } catch (err) {
-          this.logger.warn({ err, date, url }, 'Failed to process daily stats')
+          this.stats.errors++
+          this.lastError = err
+          this.logger.error({ err, date, url }, 'Failed to process daily stats')
         }
       }
 
       // Flush any remaining batches
       if (versionBatch.length > 0) {
+        this.logger.debug({ batchSize: versionBatch.length }, 'Flushing final version batch')
         this.db.insertVersionDownloadsBatch(versionBatch)
       }
       if (osBatch.length > 0) {
+        this.logger.debug({ batchSize: osBatch.length }, 'Flushing final OS batch')
         this.db.insertOsDownloadsBatch(osBatch)
       }
 
       // Update last update timestamp
       this.db.setLastUpdate(new Date().toISOString())
 
-      this.logger.info('Data ingestion completed successfully')
+      this.logger.info({
+        stats: this.stats
+      }, 'Data ingestion completed successfully')
     } catch (err) {
+      this.lastError = err
       this.logger.error({ err }, 'Data ingestion failed')
       throw err
     } finally {
@@ -183,10 +253,14 @@ class DataIngester {
       const obj = parser.parse(await response.body.text())
 
       const contents = (obj.ListBucketResult && obj.ListBucketResult.Contents) || []
+      this.logger.debug({ pageSize: contents.length }, 'Got bucket listing page')
 
       for (const key of contents) {
         const match = key.Key.match(/nodejs\.org-access\.log\.(\d{4})(\d{2})(\d{2})\.json/)
-        if (!match) continue
+        if (!match) {
+          this.logger.trace({ key: key.Key }, 'Skipping non-matching key')
+          continue
+        }
 
         const year = match[1]
         const month = match[2]
@@ -223,6 +297,10 @@ class DataIngester {
 
     // Sort by date
     availableData.sort((a, b) => a.date.localeCompare(b.date))
+    this.logger.info({ 
+      totalFiles: availableData.length,
+      dateRange: availableData.length > 0 ? `${availableData[0].date} to ${availableData[availableData.length - 1].date}` : 'none'
+    }, 'Listed available files')
 
     return availableData
   }
@@ -246,6 +324,15 @@ class DataIngester {
     }
 
     this.isIngesting = true
+    this.lastError = null
+    this.stats = {
+      totalFiles: 0,
+      processedFiles: 0,
+      versionRecords: 0,
+      osRecords: 0,
+      errors: 0,
+      byVersion: {}
+    }
     this.logger.info('Starting data ingestion from GCS')
 
     try {
@@ -267,6 +354,7 @@ class DataIngester {
 
       // Fetch available files from GCS
       const availableData = await this.listAvailableFiles(mostRecentDate)
+      this.stats.totalFiles = availableData.length
 
       // Skip current month
       const today = new Date()
@@ -289,30 +377,83 @@ class DataIngester {
         onProgress({ processed: 0, total: toDownload.length })
       }
 
-      // Process downloads sequentially with yields
+      // Process downloads sequentially with batches
       let processed = 0
+      const versionBatch = []
+      const osBatch = []
+      const BATCH_SIZE = 500
+
       for (const { date, url } of toDownload) {
         try {
+          this.logger.debug({ date, url }, 'Fetching daily stats file')
           const response = await undici.request(url, { dispatcher: this.agent })
           const result = await response.body.json()
 
-          // Process version data
+          // Debug: log all version keys found
           const versionKeys = Object.keys(result.version || {})
+          this.logger.debug({ 
+            date, 
+            versionCount: versionKeys.length,
+            sampleVersions: versionKeys.slice(0, 5)
+          }, 'Found versions in file')
+          
+          let versionsInserted = 0
           for (const key of versionKeys) {
+            this.logger.trace({ key, date }, 'Parsing version')
             const version = semver.parse(key)
-            if (!version) continue
-            if (version.major < 4) continue
+            if (!version) {
+              this.logger.warn({ key, date }, 'Failed to parse version - skipping')
+              continue
+            }
+            if (version.major < 4) {
+              this.logger.trace({ key, major: version.major, date }, 'Skipping version < 4')
+              continue
+            }
 
-            this.db.insertVersionDownload(date, version.major, result.version[key])
+            this.logger.trace({ date, version: key, major: version.major }, 'Adding to version batch')
+            versionBatch.push({
+              date,
+              majorVersion: version.major,
+              downloads: result.version[key]
+            })
+            versionsInserted++
+            this.stats.versionRecords++
+            
+            // Track by version for debugging
+            if (!this.stats.byVersion[version.major]) {
+              this.stats.byVersion[version.major] = 0
+            }
+            this.stats.byVersion[version.major]++
+
+            // Flush batch when it reaches threshold
+            if (versionBatch.length >= BATCH_SIZE) {
+              this.db.insertVersionDownloadsBatch(versionBatch.splice(0, BATCH_SIZE))
+            }
           }
+          this.logger.debug({ date, versionsInserted }, 'Added versions for date')
 
           // Process OS data
           const osKeys = Object.keys(result.os || {})
+          let osInserted = 0
           for (const os of osKeys) {
-            this.db.insertOsDownload(date, os, result.os[os])
+            this.logger.trace({ date, os }, 'Adding to OS batch')
+            osBatch.push({
+              date,
+              os,
+              downloads: result.os[os]
+            })
+            osInserted++
+            this.stats.osRecords++
+
+            // Flush batch when it reaches threshold
+            if (osBatch.length >= BATCH_SIZE) {
+              this.db.insertOsDownloadsBatch(osBatch.splice(0, BATCH_SIZE))
+            }
           }
+          this.logger.debug({ date, osInserted }, 'Added OS records for date')
 
           processed++
+          this.stats.processedFiles = processed
           if (onProgress && processed % 5 === 0) {
             onProgress({ processed, total: toDownload.length })
           }
@@ -322,8 +463,18 @@ class DataIngester {
             await new Promise(resolve => setImmediate(resolve))
           }
         } catch (err) {
-          this.logger.warn({ err, date, url }, 'Failed to process daily stats')
+          this.stats.errors++
+          this.lastError = err
+          this.logger.error({ err, date, url }, 'Failed to process daily stats')
         }
+      }
+
+      // Flush remaining batches
+      if (versionBatch.length > 0) {
+        this.db.insertVersionDownloadsBatch(versionBatch)
+      }
+      if (osBatch.length > 0) {
+        this.db.insertOsDownloadsBatch(osBatch)
       }
 
       if (onProgress) {
@@ -333,12 +484,37 @@ class DataIngester {
       // Update last update timestamp
       this.db.setLastUpdate(new Date().toISOString())
 
-      this.logger.info('Data ingestion completed successfully')
+      this.logger.info({
+        stats: this.stats
+      }, 'Data ingestion completed successfully')
     } catch (err) {
+      this.lastError = err
       this.logger.error({ err }, 'Data ingestion failed')
       throw err
     } finally {
       this.isIngesting = false
+    }
+  }
+
+  getStats () {
+    return {
+      isIngesting: this.isIngesting,
+      lastError: this.lastError ? this.lastError.message : null,
+      stats: this.stats
+    }
+  }
+
+  reset () {
+    this.logger.info('Resetting ingestion state')
+    this.isIngesting = false
+    this.lastError = null
+    this.stats = {
+      totalFiles: 0,
+      processedFiles: 0,
+      versionRecords: 0,
+      osRecords: 0,
+      errors: 0,
+      byVersion: {}
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@fastify/bearer-auth": "^10.0.0",
         "@fastify/static": "^8.0.0",
         "@platformatic/config": "^2.75.2",
         "@platformatic/service": "^3.0.0",
@@ -142,6 +143,26 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/@fastify/basic-auth/-/basic-auth-6.2.0.tgz",
       "integrity": "sha512-Ao9Jf8TyW8v7p3CPy++c+E3qcCDeWfAlSIfFo0CsKrfvm81i0OCpnobIMwaSSkg/At0rzsLzbJPDWrgNru0G1w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastify-plugin": "^5.0.0"
+      }
+    },
+    "node_modules/@fastify/bearer-auth": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@fastify/bearer-auth/-/bearer-auth-10.1.2.tgz",
+      "integrity": "sha512-9WaHql+IdH03doWS1pNDcO/AcAVskoESAC+sI56+euTWMW12ZUz+xTMNPvIwr8jMJlnTnrU9aI+lD7LMWf9POA==",
       "funding": [
         {
           "type": "github",
@@ -2451,7 +2472,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "test": "node --test test/*/*.test.js"
   },
   "dependencies": {
+    "@fastify/bearer-auth": "^10.0.0",
     "@fastify/static": "^8.0.0",
     "@platformatic/config": "^2.75.2",
     "@platformatic/service": "^3.0.0",

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,0 +1,150 @@
+/// <reference path="../global.d.ts" />
+'use strict'
+
+const { DataIngester } = require('../lib/ingest')
+
+/** @param {import('fastify').FastifyInstance} fastify */
+module.exports = async function (fastify, opts) {
+  // Get database from fastify decorator
+  const db = fastify.db
+  if (!db) {
+    throw new Error('Database not initialized - ensure database plugin is registered before admin routes')
+  }
+
+  // Store reference to ingester for stats
+  let ingester = null
+
+  // Check if admin API is enabled via environment variable
+  const adminAuthEnabled = process.env.NODEJS_DOWNLOAD_STATS_ADMIN_AUTH
+
+  // Basic auth middleware
+  async function verifyAuth (request, reply) {
+    if (!adminAuthEnabled) {
+      reply.code(403)
+      return { error: 'Admin API not enabled' }
+    }
+
+    const authHeader = request.headers.authorization
+    if (!authHeader || !authHeader.startsWith('Basic ')) {
+      reply.code(401)
+      reply.header('WWW-Authenticate', 'Basic realm="admin"')
+      return { error: 'Authentication required' }
+    }
+
+    const base64 = authHeader.slice(6)
+    const decoded = Buffer.from(base64, 'base64').toString('utf-8')
+    const [username, password] = decoded.split(':')
+
+    const [expectedUser, expectedPass] = adminAuthEnabled.split(':')
+    if (username !== expectedUser || password !== expectedPass) {
+      reply.code(401)
+      return { error: 'Invalid credentials' }
+    }
+
+    return null // Auth passed
+  }
+
+  // Expose ingestion stats (read-only, no auth needed)
+  fastify.get('/admin/ingestion-stats', async (request, reply) => {
+    const versionRows = db.getDailyVersionDownloads()
+    const monthlyVersionRows = db.getMonthlyVersionDownloads()
+
+    // Calculate unique versions found
+    const versions = new Set()
+    for (const { major_version } of monthlyVersionRows) {
+      versions.add(major_version)
+    }
+
+    const stats = {
+      dailyRecords: versionRows.length,
+      monthlyRecords: monthlyVersionRows.length,
+      uniqueVersions: [...versions].sort((a, b) => a - b),
+      totalDailyDownloads: versionRows.reduce((sum, row) => sum + row.downloads, 0),
+      lastUpdate: db.getLastUpdate(),
+      mostRecentDate: db.getMostRecentDate(),
+      ingesterStats: ingester ? ingester.getStats() : null
+    }
+
+    return stats
+  })
+
+  // Trigger ingestion (requires auth)
+  fastify.post('/admin/retrigger-ingestion', async (request, reply) => {
+    const authError = await verifyAuth(request, reply)
+    if (authError) return authError
+
+    const { clearData = false, resetOnly = false } = request.body || {}
+
+    if (resetOnly) {
+      if (ingester) {
+        ingester.reset()
+      }
+      return { message: 'Ingestion state reset' }
+    }
+
+    // Clear data if requested
+    if (clearData) {
+      fastify.log.warn('Clearing all download data as requested')
+      db.clearData()
+    }
+
+    // Create new ingester and trigger ingestion
+    ingester = new DataIngester(fastify.log, db)
+
+    // Start ingestion in background
+    ingester.ingest().catch(err => {
+      fastify.log.error({ err }, 'Manual ingestion failed')
+    })
+
+    return {
+      message: 'Ingestion triggered',
+      clearData,
+      status: ingester.getStats()
+    }
+  })
+
+  // Get raw data for a specific date (for debugging)
+  fastify.get('/admin/raw-data/:date', async (request, reply) => {
+    const { date } = request.params
+
+    // Validate date format
+    if (!date.match(/^\d{4}-\d{2}-\d{2}$/)) {
+      reply.code(400)
+      return { error: 'Invalid date format, expected YYYY-MM-DD' }
+    }
+
+    // Fetch from GCS
+    try {
+      const undici = require('undici')
+      const url = `https://storage.googleapis.com/access-logs-summaries-nodejs/nodejs.org-access.log.${date.replace(/-/g, '')}.json`
+      const response = await undici.request(url)
+      const data = await response.body.json()
+
+      return {
+        date,
+        url,
+        versions: Object.keys(data.version || {}).sort(),
+        os: Object.keys(data.os || {}).sort(),
+        sampleVersionData: Object.entries(data.version || {}).slice(0, 5).map(([k, v]) => ({ version: k, downloads: v }))
+      }
+    } catch (err) {
+      reply.code(500)
+      return { error: 'Failed to fetch raw data', details: err.message }
+    }
+  })
+
+  // Health check
+  fastify.get('/admin/health', async (request, reply) => {
+    const versionRows = db.getDailyVersionDownloads()
+    const monthlyVersionRows = db.getMonthlyVersionDownloads()
+
+    return {
+      healthy: true,
+      database: {
+        dailyRecords: versionRows.length,
+        monthlyRecords: monthlyVersionRows.length,
+        uniqueVersions: new Set(monthlyVersionRows.map(r => r.major_version)).size
+      }
+    }
+  })
+}

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -81,7 +81,7 @@ module.exports = async function (fastify, opts) {
     }
 
     // Create new ingester and trigger ingestion
-    ingester = new DataIngester(fastify.log, db)
+    ingester = new DataIngester(fastify.log, db, opts.ingesterAgent)
 
     // Start ingestion in background
     ingester.ingest().catch(err => {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -53,7 +53,17 @@ module.exports = async function (fastify, opts) {
 
   // Trigger ingestion (requires auth)
   fastify.post('/admin/retrigger-ingestion', {
-    onRequest: fastify.verifyBearerAuth
+    onRequest: fastify.verifyBearerAuth,
+    schema: {
+      body: {
+        type: 'object',
+        properties: {
+          clearData: { type: 'boolean', default: false },
+          resetOnly: { type: 'boolean', default: false }
+        },
+        additionalProperties: false
+      }
+    }
   }, async (request, reply) => {
     const { clearData = false, resetOnly = false } = request.body || {}
 

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -65,7 +65,7 @@ module.exports = async function (fastify, opts) {
       }
     }
   }, async (request, reply) => {
-    const { clearData = false, resetOnly = false } = request.body || {}
+    const { clearData, resetOnly } = request.body
 
     if (resetOnly) {
       if (ingester) {

--- a/test/routes/admin.test.js
+++ b/test/routes/admin.test.js
@@ -1,0 +1,369 @@
+'use strict'
+
+const assert = require('node:assert')
+const test = require('node:test')
+const fastify = require('fastify')
+const path = require('node:path')
+const adminRoute = require('../../routes/admin.js')
+
+test('admin/health returns healthy status', async () => {
+  const app = fastify()
+
+  const mockDb = {
+    getDailyVersionDownloads: () => [
+      { date: '2024-01-01', major_version: 18, downloads: 100 },
+      { date: '2024-01-02', major_version: 18, downloads: 200 }
+    ],
+    getMonthlyVersionDownloads: () => [
+      { major_version: 18, month: '2024-01', total_downloads: 300 },
+      { major_version: 20, month: '2024-01', total_downloads: 500 }
+    ],
+    getMonthlyOsDownloads: () => [],
+    getDailyOsDownloads: () => []
+  }
+  app.decorate('db', mockDb)
+
+  await app.register(adminRoute, {})
+
+  const response = await app.inject({
+    method: 'GET',
+    url: '/admin/health'
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  const json = JSON.parse(response.payload)
+  assert.strictEqual(json.healthy, true)
+  assert.strictEqual(json.database.dailyRecords, 2)
+  assert.strictEqual(json.database.monthlyRecords, 2)
+  assert.strictEqual(json.database.uniqueVersions, 2)
+
+  await app.close()
+})
+
+test('admin/ingestion-stats returns database stats', async () => {
+  const app = fastify()
+
+  const mockDb = {
+    getDailyVersionDownloads: () => [
+      { date: '2024-01-01', major_version: 18, downloads: 100 },
+      { date: '2024-01-02', major_version: 20, downloads: 200 }
+    ],
+    getMonthlyVersionDownloads: () => [
+      { major_version: 18, month: '2024-01', total_downloads: 100 },
+      { major_version: 20, month: '2024-01', total_downloads: 200 }
+    ],
+    getLastUpdate: () => ({ value: '2024-01-01T00:00:00Z', updatedAt: 1704067200000 }),
+    getMostRecentDate: () => '2024-01-02'
+  }
+  app.decorate('db', mockDb)
+
+  process.env.NODEJS_DOWNLOAD_STATS_ADMIN_AUTH = 'admin:testpass'
+  await app.register(adminRoute, {})
+
+  const response = await app.inject({
+    method: 'GET',
+    url: '/admin/ingestion-stats'
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  const json = JSON.parse(response.payload)
+
+  assert.strictEqual(json.dailyRecords, 2)
+  assert.strictEqual(json.monthlyRecords, 2)
+  assert.deepStrictEqual(json.uniqueVersions, [18, 20])
+  assert.ok(json.totalDailyDownloads > 0)
+  assert.strictEqual(json.mostRecentDate, '2024-01-02')
+  assert.ok(json.lastUpdate)
+  assert.ok(json.ingesterStats)
+
+  delete process.env.NODEJS_DOWNLOAD_STATS_ADMIN_AUTH
+  await app.close()
+})
+
+test('admin/retrigger-ingestion returns 403 when auth not enabled', async () => {
+  const app = fastify()
+
+  const mockDb = {
+    clearData: () => {},
+    getExistingDates: () => [],
+    insertVersionDownload: () => {},
+    insertOsDownload: () => {},
+    getDailyVersionDownloads: () => []
+  }
+  app.decorate('db', mockDb)
+
+  // No env var set
+  delete process.env.NODEJS_DOWNLOAD_STATS_ADMIN_AUTH
+
+  await app.register(adminRoute, {})
+
+  const response = await app.inject({
+    method: 'POST',
+    url: '/admin/retrigger-ingestion'
+  })
+
+  assert.strictEqual(response.statusCode, 403)
+  const json = JSON.parse(response.payload)
+  assert.ok(json.error.includes('not enabled'))
+
+  await app.close()
+})
+
+test('admin/retrigger-ingestion returns 401 without authentication', async () => {
+  const app = fastify()
+
+  const mockDb = {
+    clearData: () => {},
+    getDailyVersionDownloads: () => []
+  }
+  app.decorate('db', mockDb)
+
+  process.env.NODEJS_DOWNLOAD_STATS_ADMIN_AUTH = 'admin:secret'
+  await app.register(adminRoute, {})
+
+  const response = await app.inject({
+    method: 'POST',
+    url: '/admin/retrigger-ingestion'
+  })
+
+  assert.strictEqual(response.statusCode, 401)
+  assert.ok(response.headers['www-authenticate'])
+
+  delete process.env.NODEJS_DOWNLOAD_STATS_ADMIN_AUTH
+  await app.close()
+})
+
+test('admin/retrigger-ingestion returns 401 with invalid credentials', async () => {
+  const app = fastify()
+
+  const mockDb = {
+    clearData: () => {},
+    getDailyVersionDownloads: () => []
+  }
+  app.decorate('db', mockDb)
+
+  process.env.NODEJS_DOWNLOAD_STATS_ADMIN_AUTH = 'admin:secret'
+  await app.register(adminRoute, {})
+
+  const response = await app.inject({
+    method: 'POST',
+    url: '/admin/retrigger-ingestion',
+    headers: {
+      authorization: 'Basic ' + Buffer.from('wrong:wrong').toString('base64')
+    }
+  })
+
+  assert.strictEqual(response.statusCode, 401)
+
+  delete process.env.NODEJS_DOWNLOAD_STATS_ADMIN_AUTH
+  await app.close()
+})
+
+test('admin/retrigger-ingestion works with valid auth', async () => {
+  const app = fastify()
+
+  const mockDb = {
+    clearData: () => {},
+    getDailyVersionDownloads: () => [],
+    getLastUpdate: () => null,
+    getExistingDates: () => [],
+    getMostRecentDate: () => null,
+    insertVersionDownload: () => {},
+    insertOsDownload: () => {},
+    setLastUpdate: () => {}
+  }
+  app.decorate('db', mockDb)
+
+  process.env.NODEJS_DOWNLOAD_STATS_ADMIN_AUTH = 'admin:secretpassword'
+  await app.register(adminRoute, {})
+
+  const response = await app.inject({
+    method: 'POST',
+    url: '/admin/retrigger-ingestion',
+    headers: {
+      authorization: 'Basic ' + Buffer.from('admin:secretpassword').toString('base64')
+    }
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  const json = JSON.parse(response.payload)
+  assert.ok(json.message.includes('triggered'))
+  assert.strictEqual(json.clearData, undefined)
+
+  delete process.env.NODEJS_DOWNLOAD_STATS_ADMIN_AUTH
+  await app.close()
+})
+
+test('admin/retrigger-ingestion supports clearData option', async () => {
+  const app = fastify()
+
+  let clearDataCalled = false
+  const mockDb = {
+    clearData: () => { clearDataCalled = true },
+    getDailyVersionDownloads: () => [],
+    getLastUpdate: () => null,
+    getExistingDates: () => [],
+    getMostRecentDate: () => null,
+    insertVersionDownload: () => {},
+    insertOsDownload: () => {},
+    setLastUpdate: () => {}
+  }
+  app.decorate('db', mockDb)
+
+  process.env.NODEJS_DOWNLOAD_STATS_ADMIN_AUTH = 'admin:secret'
+  await app.register(adminRoute, {})
+
+  const response = await app.inject({
+    method: 'POST',
+    url: '/admin/retrigger-ingestion',
+    headers: {
+      authorization: 'Basic ' + Buffer.from('admin:secret').toString('base64'),
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ clearData: true })
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(clearDataCalled, true)
+  const json = JSON.parse(response.payload)
+  assert.strictEqual(json.clearData, true)
+
+  delete process.env.NODEJS_DOWNLOAD_STATS_ADMIN_AUTH
+  await app.close()
+})
+
+test('admin/retrigger-ingestion supports resetOnly option', async () => {
+  const app = fastify()
+
+  const mockDb = {
+    getDailyVersionDownloads: () => []
+  }
+  app.decorate('db', mockDb)
+
+  process.env.NODEJS_DOWNLOAD_STATS_ADMIN_AUTH = 'admin:secret'
+  await app.register(adminRoute, {})
+
+  const response = await app.inject({
+    method: 'POST',
+    url: '/admin/retrigger-ingestion',
+    headers: {
+      authorization: 'Basic ' + Buffer.from('admin:secret').toString('base64'),
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ resetOnly: true })
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  const json = JSON.parse(response.payload)
+  assert.ok(json.message.includes('reset'))
+
+  delete process.env.NODEJS_DOWNLOAD_STATS_ADMIN_AUTH
+  await app.close()
+})
+
+test('admin/raw-data/:date returns version list for valid date', async () => {
+  const app = fastify()
+
+  const mockDb = {
+    getDailyVersionDownloads: () => [],
+    getMonthlyVersionDownloads: () => [],
+    getMonthlyOsDownloads: () => []
+  }
+  app.decorate('db', mockDb)
+
+  await app.register(adminRoute, {})
+
+  // This test would need network access - just verify the endpoint exists
+  // and returns appropriate error or success structure
+  const response = await app.inject({
+    method: 'GET',
+    url: '/admin/raw-data/2021-01-01'
+  })
+
+  // Will either succeed (if we have network) or fail with 500 (if no network)
+  // Just verify it's not a 404
+  assert.ok(response.statusCode === 200 || response.statusCode === 500)
+
+  await app.close()
+})
+
+test('admin/raw-data/:date returns 400 for invalid date format', async () => {
+  const app = fastify()
+
+  const mockDb = {
+    getDailyVersionDownloads: () => [],
+    getMonthlyVersionDownloads: () => [],
+    getMonthlyOsDownloads: () => []
+  }
+  app.decorate('db', mockDb)
+
+  await app.register(adminRoute, {})
+
+  const response = await app.inject({
+    method: 'GET',
+    url: '/admin/raw-data/invalid-date'
+  })
+
+  assert.strictEqual(response.statusCode, 400)
+  const json = JSON.parse(response.payload)
+  assert.ok(json.error.includes('Invalid date'))
+
+  await app.close()
+})
+
+test('DataIngester getStats returns current state', () => {
+  const { DataIngester } = require('../../lib/ingest.js')
+  const mockDb = {
+    getLastUpdate: () => null,
+    getMostRecentDate: () => null,
+    getExistingDates: () => [],
+    listAvailableFiles: () => Promise.resolve([])
+  }
+  const mockLogger = {
+    info: () => {},
+    debug: () => {},
+    warn: () => {},
+    error: () => {},
+    trace: () => {}
+  }
+
+  const ingester = new DataIngester(mockLogger, mockDb)
+
+  const stats = ingester.getStats()
+
+  assert.strictEqual(stats.isIngesting, false)
+  assert.strictEqual(stats.lastError, null)
+  assert.ok(stats.stats)
+  assert.strictEqual(stats.stats.totalFiles, 0)
+  assert.strictEqual(stats.stats.processedFiles, 0)
+})
+
+test('DataIngester reset clears state', () => {
+  const { DataIngester } = require('../../lib/ingest.js')
+  const mockDb = {
+    getLastUpdate: () => null,
+    getMostRecentDate: () => null,
+    getExistingDates: () => [],
+    listAvailableFiles: () => Promise.resolve([])
+  }
+  const mockLogger = {
+    info: () => {},
+    debug: () => {},
+    warn: () => {},
+    error: () => {},
+    trace: () => {}
+  }
+
+  const ingester = new DataIngester(mockLogger, mockDb)
+
+  // Set some fake state
+  ingester.isIngesting = true
+  ingester.stats.processedFiles = 100
+  ingester.stats.byVersion = { 18: 50 }
+
+  ingester.reset()
+
+  assert.strictEqual(ingester.isIngesting, false)
+  assert.strictEqual(ingester.stats.processedFiles, 0)
+  assert.deepStrictEqual(ingester.stats.byVersion, {})
+})

--- a/test/routes/admin.test.js
+++ b/test/routes/admin.test.js
@@ -80,7 +80,7 @@ test('admin/ingestion-stats returns database stats', async () => {
   await app.close()
 })
 
-test('admin/retrigger-ingestion returns 403 when auth not enabled', async () => {
+test('admin routes not registered when auth not enabled', async () => {
   const app = fastify()
 
   const mockDb = {
@@ -97,14 +97,13 @@ test('admin/retrigger-ingestion returns 403 when auth not enabled', async () => 
 
   await app.register(adminRoute, {})
 
+  // Routes should not exist - should return 404
   const response = await app.inject({
     method: 'POST',
     url: '/admin/retrigger-ingestion'
   })
 
-  assert.strictEqual(response.statusCode, 403)
-  const json = JSON.parse(response.payload)
-  assert.ok(json.error.includes('not enabled'))
+  assert.strictEqual(response.statusCode, 404)
 
   await app.close()
 })

--- a/test/routes/admin.test.js
+++ b/test/routes/admin.test.js
@@ -194,7 +194,9 @@ test('admin/retrigger-ingestion works with valid auth', async () => {
     </ListBucketResult>`).persist()
 
   process.env.NODEJS_DOWNLOAD_STATS_ADMIN_AUTH = AUTH_TOKEN
-  await app.register(adminRoute, { ingesterAgent: mockAgent })
+  // Set mock agent as global dispatcher so DataIngester uses it
+  undici.setGlobalDispatcher(mockAgent)
+  await app.register(adminRoute, {})
 
   const response = await app.inject({
     method: 'POST',
@@ -203,7 +205,7 @@ test('admin/retrigger-ingestion works with valid auth', async () => {
       ...authHeader(AUTH_TOKEN),
       'content-type': 'application/json'
     },
-    body: '{}'
+    body: JSON.stringify({})
   })
 
   assert.strictEqual(response.statusCode, 200)
@@ -248,7 +250,9 @@ test('admin/retrigger-ingestion supports clearData option', async () => {
     </ListBucketResult>`).persist()
 
   process.env.NODEJS_DOWNLOAD_STATS_ADMIN_AUTH = AUTH_TOKEN
-  await app.register(adminRoute, { ingesterAgent: mockAgent })
+  // Set mock agent as global dispatcher so DataIngester uses it
+  undici.setGlobalDispatcher(mockAgent)
+  await app.register(adminRoute, {})
 
   const response = await app.inject({
     method: 'POST',


### PR DESCRIPTION
# Debug Logging and Admin API for Ingestion

This PR adds extensive debug logging and an admin API to help diagnose why only version 4 data is appearing in production.

## Debug Logging Improvements

The `DataIngester` now logs at multiple levels:

- **trace**: Individual version parsing attempts, insertions
- **debug**: File processing status, version counts per file, sample versions found
- **info**: Summary stats showing records by version during progress reports
- **warn**: Failed version parsing, processing errors

Example logs you'll see:
```
Found versions in file: { date: "2024-02-09", versionCount: 342, sampleVersions: ["v22.13.1", "v20.18.2", ...] }
Ingestion progress: { processed: 100, total: 1819, versionRecords: 5230, byVersion: { "4": 100, "18": 1200, "20": 2400, ... } }
```

This will immediately show if:
- Versions are being found in downloaded files
- semver.parse() is failing on version strings
- Certain versions are being filtered out

## Admin API (routes/admin.js)

### Endpoints

**GET /admin/ingestion-stats** (public)
Returns current database state:
```json
{
  "dailyRecords": 1820,
  "monthlyRecords": 24000,
  "uniqueVersions": [4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 23],
  "totalDailyDownloads": 2847293847,
  "lastUpdate": { "value": "2026-02-10T14:00:00Z", "updatedAt": 1739210400000 },
  "mostRecentDate": "2025-02-09",
  "ingesterStats": { "isIngesting": false, "byVersion": { ... } }
}
```

**POST /admin/retrigger-ingestion** (requires auth)
Retriggers data ingestion. Headers: `Authorization: Basic base64(user:pass)`

Request body options:
- `clearData: true` - Clears all data before reprocessing (full reset)
- `resetOnly: true` - Just resets ingestion state without triggering

Example:
```bash
curl -X POST -u admin:secretpassword \
  https://nodedownloads.nodeland.dev/admin/retrigger-ingestion \
  -H "Content-Type: application/json" \
  -d '{"clearData": true}'
```

**GET /admin/raw-data/:date** (public)
Fetches raw GCS data for a specific date (format: YYYY-MM-DD). Useful to verify what versions exist in source files:
```bash
curl https://nodedownloads.nodeland.dev/admin/raw-data/2024-02-09
```

**GET /admin/health** (public)
Quick health check with database stats.

## Environment Variable

To enable the admin API, set:
```bash
NODEJS_DOWNLOAD_STATS_ADMIN_AUTH=username:password
```

If not set, the POST endpoint returns 403 Forbidden.

## Diagnosing the v4-only Issue

After deploying this PR:

1. Check current state:
   ```bash
   curl https://nodedownloads.nodeland.dev/admin/ingestion-stats
   ```

2. Check raw data for a recent date to see what versions exist:
   ```bash
   curl https://nodedownloads.nodeland.dev/admin/raw-data/2025-02-09
   ```

3. Check logs for trace/debug output showing what versions are being found and inserted

4. If needed, trigger full re-ingestion:
   ```bash
   curl -X POST -u admin:YOURPASSWORD \
     https://nodedownloads.nodeland.dev/admin/retrigger-ingestion \
     -d '{"clearData": true}'
   ```
   Then watch the ingestion progress via logs.
