### PR TITLE
Add log when admin routes are enabled

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -11,6 +11,8 @@ module.exports = async function (fastify, opts) {
     return // Skip registration entirely if admin API is not enabled
   }
 
+  fastify.log.info('Admin routes enabled')
+
   // Get database from fastify decorator
   const db = fastify.db
   if (!db) {


### PR DESCRIPTION
Logs a message when NODEJS_DOWNLOAD_STATS_ADMIN_AUTH is set and admin routes are registered.