### PR TITLE
Fix: Aggregate version downloads by major version to prevent data loss

### DIFF
--- a/lib/ingest.js
+++ b/lib/ingest.js
@@ -103,6 +103,10 @@ class DataIngester {
       const osBatch = []
       const BATCH_SIZE = 500 // Flush batch after this many entries
 
+      // Use a Map to aggregate downloads by (date, majorVersion) before batching
+      // This prevents the unique constraint from overwriting data
+      const versionAggregates = new Map()
+
       for (const { date, url } of toDownload) {
         try {
           this.logger.debug({ date, url }, 'Fetching daily stats file')
@@ -118,6 +122,9 @@ class DataIngester {
           }, 'Found versions in file')
           
           let versionsInserted = 0
+          // Aggregate downloads by major version for this date
+          const dateVersionTotals = new Map()
+          
           for (const key of versionKeys) {
             this.logger.trace({ key, date }, 'Parsing version')
             const version = semver.parse(key)
@@ -130,12 +137,9 @@ class DataIngester {
               continue
             }
 
-            this.logger.trace({ date, version: key, major: version.major, downloads: result.version[key] }, 'Adding to version batch')
-            versionBatch.push({
-              date,
-              majorVersion: version.major,
-              downloads: result.version[key]
-            })
+            // Aggregate downloads by major version to prevent unique constraint overwrites
+            const currentTotal = dateVersionTotals.get(version.major) || 0
+            dateVersionTotals.set(version.major, currentTotal + result.version[key])
             versionsInserted++
             this.stats.versionRecords++
             
@@ -144,6 +148,15 @@ class DataIngester {
               this.stats.byVersion[version.major] = 0
             }
             this.stats.byVersion[version.major]++
+          }
+          
+          // Add aggregated version data to batch
+          for (const [majorVersion, totalDownloads] of dateVersionTotals) {
+            versionBatch.push({
+              date,
+              majorVersion,
+              downloads: totalDownloads
+            })
 
             // Flush batch when it reaches threshold
             if (versionBatch.length >= BATCH_SIZE) {
@@ -151,7 +164,8 @@ class DataIngester {
               this.db.insertVersionDownloadsBatch(versionBatch.splice(0, BATCH_SIZE))
             }
           }
-          this.logger.debug({ date, versionsInserted }, 'Added versions for date')
+          
+          this.logger.debug({ date, versionsInserted, versionsAggregated: dateVersionTotals.size }, 'Added versions for date')
 
           // Accumulate OS data
           const osKeys = Object.keys(result.os || {})
@@ -398,6 +412,9 @@ class DataIngester {
           }, 'Found versions in file')
           
           let versionsInserted = 0
+          // Aggregate downloads by major version for this date
+          const dateVersionTotals = new Map()
+          
           for (const key of versionKeys) {
             this.logger.trace({ key, date }, 'Parsing version')
             const version = semver.parse(key)
@@ -410,12 +427,9 @@ class DataIngester {
               continue
             }
 
-            this.logger.trace({ date, version: key, major: version.major }, 'Adding to version batch')
-            versionBatch.push({
-              date,
-              majorVersion: version.major,
-              downloads: result.version[key]
-            })
+            // Aggregate downloads by major version to prevent unique constraint overwrites
+            const currentTotal = dateVersionTotals.get(version.major) || 0
+            dateVersionTotals.set(version.major, currentTotal + result.version[key])
             versionsInserted++
             this.stats.versionRecords++
             
@@ -424,13 +438,23 @@ class DataIngester {
               this.stats.byVersion[version.major] = 0
             }
             this.stats.byVersion[version.major]++
+          }
+          
+          // Add aggregated version data to batch
+          for (const [majorVersion, totalDownloads] of dateVersionTotals) {
+            versionBatch.push({
+              date,
+              majorVersion,
+              downloads: totalDownloads
+            })
 
             // Flush batch when it reaches threshold
             if (versionBatch.length >= BATCH_SIZE) {
               this.db.insertVersionDownloadsBatch(versionBatch.splice(0, BATCH_SIZE))
             }
           }
-          this.logger.debug({ date, versionsInserted }, 'Added versions for date')
+          
+          this.logger.debug({ date, versionsInserted, versionsAggregated: dateVersionTotals.size }, 'Added versions for date')
 
           // Process OS data
           const osKeys = Object.keys(result.os || {})

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -11,6 +11,8 @@ module.exports = async function (fastify, opts) {
     return // Skip registration entirely if admin API is not enabled
   }
 
+  fastify.log.info('Admin routes enabled')
+
   // Get database from fastify decorator
   const db = fastify.db
   if (!db) {


### PR DESCRIPTION
Fixes version data being overwritten due to unique constraint. Downloads now aggregated by major version before inserting.