### PR TITLE
Fix: clearData clears last_update and remove resetOnly

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -160,6 +160,7 @@ class Database {
     const db = this.getDb()
     db.exec('DELETE FROM version_downloads')
     db.exec('DELETE FROM os_downloads')
+    db.exec("DELETE FROM metadata WHERE key = 'last_update'")
   }
 
   getVersionDownloads () {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -60,21 +60,13 @@ module.exports = async function (fastify, opts) {
       body: {
         type: 'object',
         properties: {
-          clearData: { type: 'boolean', default: false },
-          resetOnly: { type: 'boolean', default: false }
+          clearData: { type: 'boolean', default: false }
         },
         additionalProperties: false
       }
     }
   }, async (request, reply) => {
-    const { clearData, resetOnly } = request.body
-
-    if (resetOnly) {
-      if (ingester) {
-        ingester.reset()
-      }
-      return { message: 'Ingestion state reset' }
-    }
+    const { clearData } = request.body
 
     // Clear data if requested
     if (clearData) {

--- a/test/routes/admin.test.js
+++ b/test/routes/admin.test.js
@@ -274,35 +274,6 @@ test('admin/retrigger-ingestion supports clearData option', async () => {
   await app.close()
 })
 
-test('admin/retrigger-ingestion supports resetOnly option', async () => {
-  const app = fastify()
-
-  const mockDb = {
-    getDailyVersionDownloads: () => []
-  }
-  app.decorate('db', mockDb)
-
-  process.env.NODEJS_DOWNLOAD_STATS_ADMIN_AUTH = AUTH_TOKEN
-  await app.register(adminRoute, {})
-
-  const response = await app.inject({
-    method: 'POST',
-    url: '/admin/retrigger-ingestion',
-    headers: {
-      ...authHeader(AUTH_TOKEN),
-      'content-type': 'application/json'
-    },
-    body: JSON.stringify({ resetOnly: true })
-  })
-
-  assert.strictEqual(response.statusCode, 200)
-  const json = JSON.parse(response.payload)
-  assert.ok(json.message.includes('reset'))
-
-  delete process.env.NODEJS_DOWNLOAD_STATS_ADMIN_AUTH
-  await app.close()
-})
-
 test('admin/raw-data/:date returns version list for valid date', async () => {
   const app = fastify()
 


### PR DESCRIPTION
This PR contains two fixes:

1. **lib/db.js**: clearData() now also clears the 'last_update' metadata entry
2. **routes/admin.js**: Remove the unnecessary resetOnly option

Root cause: When /admin/retrigger-ingestion was called with clearData: true, the download data was cleared but last_update timestamp remained, causing the 24h freshness check to skip re-ingestion.